### PR TITLE
Copy tweaks

### DIFF
--- a/class-wc-gateway-augmint.php
+++ b/class-wc-gateway-augmint.php
@@ -56,7 +56,8 @@ class WC_Gateway_Augmint extends WC_Payment_Gateway
         self::$log_enabled    = $this->debug;
 
         if ($this->testmode) {
-            $this->description .= ' ' . sprintf(__('SANDBOX ENABLED. You can use sandbox testing accounts only. See the <a href="%s">Augmint Sandbox Testing Guide</a> for more details.', 'augmint'), '');
+            /* translators: %s: URL */
+            $this->description .= ' ' . sprintf(__('TEST payment. You can use Rinkeby test ETH and A-EUR without value. No real order will be fulfilled.', 'augmint'), '');
             $this->description  = trim($this->description);
         }
 

--- a/includes/class-wc-gateway-augmint-request.php
+++ b/includes/class-wc-gateway-augmint-request.php
@@ -107,17 +107,17 @@ class WC_Gateway_Augmint_Request
         $token = md5($order->get_id() . $order->get_cart_hash());
         $order->add_order_note('Token ' . $token);
 
-        update_post_meta($order->get_id(), 'augmint_beneficiary_address', $this->gateway->get_option('augmint_address'));
+        update_post_meta($order->get_id(), 'augmint_beneficiary_address', $this->gateway->get_option('store_ethereum_address'));
 
         return array_merge(
             array(
                 'order_id' => $order->get_id(),
                 'token' => $token,
-                'beneficiary_address' => $this->gateway->get_option('augmint_address'),
+                'beneficiary_address' => $this->gateway->get_option('store_ethereum_address'),
                 'beneficiary_name' => $this->gateway->get_option('store_name'),
                 'amount' => $order->get_total(),
                 'currency_code' => 'AEUR',
-                'reference' => str_replace(array('{order_id}'), array($order->get_id()), $this->gateway->get_option('narrative')),
+                'reference' => str_replace(array('{order_id}'), array($order->get_id()), $this->gateway->get_option('payment_reference')),
                 'notify_url' => $this->gateway->get_return_url($order)
             )
         );

--- a/includes/settings-augmint.php
+++ b/includes/settings-augmint.php
@@ -11,14 +11,14 @@ return array(
     'enabled'               => array(
         'title'   => __('Enable/Disable', 'augmint'),
         'type'    => 'checkbox',
-        'label'   => __('Enable Augmint Standard', 'augmint'),
+        'label'   => __('Enable Augmint Payments', 'augmint'),
         'default' => 'no',
     ),
     'title'                 => array(
         'title'       => __('Title', 'augmint'),
         'type'        => 'text',
         'description' => __('This controls the title which the user sees during checkout.', 'augmint'),
-        'default'     => __('Augmint', 'augmint'),
+        'default'     => __('Augmint A-EUR payment', 'augmint'),
         'desc_tip'    => true,
     ),
     'description'           => array(
@@ -26,7 +26,7 @@ return array(
         'type'        => 'text',
         'desc_tip'    => true,
         'description' => __('This controls the description which the user sees during checkout.', 'augmint'),
-        'default'     => __("Pay via Augmint; you can pay with your credit card if you don't have a Augmint account.", 'augmint'),
+        'default'     => __("Pay via Augmint. It's only a few clicks to get Augmint EUR if you have ETH.", 'augmint'),
     ),
     'store_settings'              => array(
         'title'       => __('Store settings', 'augmint'),
@@ -36,15 +36,16 @@ return array(
     'store_name'                 => array(
         'title'       => __('Name', 'augmint'),
         'type'        => 'text',
-        'description' => '',
+        'description' => 'Name of store to be displayed on Augmint site during payment.',
         'default'     => __('Augmint', 'augmint'),
         'desc_tip'    => true,
     ),
     'store_ethereum_address'   => array(
         'title'       => __('Store ethereum address', 'augmint'),
         'type'        => 'text',
-        'description' => '',
+        'description' => 'The ethereum address which will receive the payments.',
         'default'     => '',
+        'placeholder' => '0x0...',
         'desc_tip'    => true,
     ),
     'payment_reference' => array(

--- a/includes/settings-augmint.php
+++ b/includes/settings-augmint.php
@@ -40,17 +40,17 @@ return array(
         'default'     => __('Augmint', 'augmint'),
         'desc_tip'    => true,
     ),
-    'augmint_address'                 => array(
-        'title'       => __('Augmint address', 'augmint'),
+    'store_ethereum_address'   => array(
+        'title'       => __('Store ethereum address', 'augmint'),
         'type'        => 'text',
         'description' => '',
         'default'     => '',
         'desc_tip'    => true,
     ),
-    'narrative'                 => array(
-        'title'       => __('Narrative', 'augmint'),
+    'payment_reference' => array(
+        'title'       => __('Payment reference', 'augmint'),
         'type'        => 'text',
-        'description' => '',
+        'description' => 'The reference which will be included in Augmint transfer. NB: this reference will be public on blockchain. Use {order_id} to insert the order number',
         'default'     => __('Order number: {order_id}', 'augmint'),
         'desc_tip'    => true,
     ),

--- a/includes/settings-augmint.php
+++ b/includes/settings-augmint.php
@@ -28,14 +28,6 @@ return array(
         'description' => __('This controls the description which the user sees during checkout.', 'augmint'),
         'default'     => __("Pay via Augmint; you can pay with your credit card if you don't have a Augmint account.", 'augmint'),
     ),
-    'email'                 => array(
-        'title'       => __('Augmint email', 'augmint'),
-        'type'        => 'email',
-        'description' => __('Please enter your Augmint email address; this is needed in order to take payment.', 'augmint'),
-        'default'     => get_option('admin_email'),
-        'desc_tip'    => true,
-        'placeholder' => 'you@youremail.com',
-    ),
     'store_settings'              => array(
         'title'       => __('Store settings', 'augmint'),
         'type'        => 'title',


### PR DESCRIPTION
- renamed `narrative` to `reference` & `augmint_address` to `store_ethereum_address`
- tweaked settings labels, description and default texts
- removed augmint email setting (not needed)